### PR TITLE
render figureProps.class as className

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    ["transform-object-assign"],
     ["transform-react-jsx"]
   ],
   "presets": ["es2015"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-- '0.10'
-- 4
 - 5
 - 6

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm test
 ## Dev Dependencies
 
 - [babel-cli](): Babel command line.
+- [babel-plugin-transform-object-assign](): Replace Object.assign with an inline helper
 - [babel-plugin-transform-react-jsx](): Turn JSX into React function calls
 - [babel-preset-es2015](): Babel preset for all es2015 plugins.
 - [babel-tape-runner](https://github.com/wavded/babel-tape-runner): Babel + Tape for running your ES Next tests

--- a/lib/components/embed.js
+++ b/lib/components/embed.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/forbid-prop-types */
 
 import React from 'react';
+import ObjectAssign from 'object-assign';
 
 const defaultRenderCaption = (text, attribution) => {
   const attributionEl = attribution.length > 0 ? <cite>{attribution}</cite> : '';
@@ -8,6 +9,10 @@ const defaultRenderCaption = (text, attribution) => {
     {text.concat([attributionEl])}
   </figcaption>);
 };
+
+const normalizeFigureProps = figureProps => figureProps && ObjectAssign({}, figureProps, {
+  className: figureProps.class,
+});
 
 const setup = ({ embeds, customCaption, renderText }) => {
   const renderCaption = customCaption || defaultRenderCaption;
@@ -26,7 +31,8 @@ const setup = ({ embeds, customCaption, renderText }) => {
       ? renderCaption(captionText, attributionText)
       : '';
 
-    return <figure {...figureProps}>{embed}{captionElm}</figure>;
+
+    return <figure {...normalizeFigureProps(figureProps)}>{embed}{captionElm}</figure>;
   };
 
   Embed.propTypes = {

--- a/lib/components/embed.js
+++ b/lib/components/embed.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/forbid-prop-types */
 
 import React from 'react';
-import ObjectAssign from 'object-assign';
 
 const defaultRenderCaption = (text, attribution) => {
   const attributionEl = attribution.length > 0 ? <cite>{attribution}</cite> : '';
@@ -10,7 +9,7 @@ const defaultRenderCaption = (text, attribution) => {
   </figcaption>);
 };
 
-const normalizeFigureProps = figureProps => figureProps && ObjectAssign({}, figureProps, {
+const normalizeFigureProps = figureProps => figureProps && Object.assign({}, figureProps, {
   className: figureProps.class,
 });
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "lodash.startswith": "^4.2.1",
+    "object-assign": "^4.1.1",
     "react": "^15.5.4",
     "react-dom": "^15.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/micnews/article-json-react-render#readme",
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-tape-runner": "^2.0.1",
@@ -33,7 +34,6 @@
   },
   "dependencies": {
     "lodash.startswith": "^4.2.1",
-    "object-assign": "^4.1.1",
     "react": "^15.5.4",
     "react-dom": "^15.5.4"
   },

--- a/test.js
+++ b/test.js
@@ -74,6 +74,27 @@ test('embed with custom figureProps', (t) => {
   t.is(actual, expected);
 });
 
+test('embed figureProps.class renders as className', (t) => {
+  const Article = setupArticle({
+    embeds: { custom: () => <span /> },
+  });
+  const items = [{
+    type: 'embed',
+    embedType: 'custom',
+    figureProps: {
+      class: 'custom-class',
+    },
+  }];
+  const actual = renderHtmlString(<Article items={items} />);
+  const expected = renderHtmlString(<article>
+    <figure className='custom-class'>
+      <span />
+    </figure>
+  </article>);
+
+  t.is(actual, expected);
+});
+
 test('text elements', (t) => {
   const Article = setupArticle({ embeds: {} });
 


### PR DESCRIPTION
Type: Patch

Since we're parsing html and not react components when creating article-json, classes comes back as `class` and not `className`, this PR makes sure we render that properly if a class is set on figureProps. 