### PR TITLE
Bugfix for: "Uncaught TypeError: Cannot call a class as a function"

### DIFF
--- a/lib/components/embed.js
+++ b/lib/components/embed.js
@@ -2,10 +2,10 @@
 
 import React from 'react';
 
-import type { RenderTextType, ElementsType } from '../types';
+import type { RenderTextType, ElementsType, EmbedsType } from '../types';
 
 type SetupType = {
-  embeds: { [string]: (Object) => React.Element<*>, },
+  embeds: EmbedsType,
   renderText: RenderTextType,
   customCaption?: (ElementsType, ElementsType) => React.Element<*>,
 };

--- a/lib/components/embed.js
+++ b/lib/components/embed.js
@@ -31,13 +31,14 @@ const normalizeFigureProps = figureProps => figureProps && Object.assign({}, fig
 const setup = ({ embeds, customCaption, renderText }: SetupType) => {
   const renderCaption = customCaption || defaultRenderCaption;
 
-  const Embed = (props: EmbedPropsType) => {
+  const EmbedWrapper = (props: EmbedPropsType) => {
     const { embedType, caption, attribution, figureProps } = props;
     if (!embeds[embedType]) {
       return null;
     }
 
-    const embed = embeds[embedType] && embeds[embedType](props);
+    const Embed = embeds[embedType];
+    const embed = <Embed {...props} />;
     const captionText = renderText(caption || []);
     const attributionText = renderText(attribution || []);
 
@@ -48,7 +49,7 @@ const setup = ({ embeds, customCaption, renderText }: SetupType) => {
     return <figure {...normalizeFigureProps(figureProps)}>{embed}{captionElm}</figure>;
   };
 
-  return Embed;
+  return EmbedWrapper;
 };
 
 export default setup;

--- a/lib/types.js
+++ b/lib/types.js
@@ -21,7 +21,9 @@ export type ElementsType = Array<ElementType>;
 export type RenderTextType = Array<TextItemType> => ElementsType;
 export type BlockListType = Array<TextItemType> => ElementsType;
 
-export type EmbedsType = { [string]: Class<React.Component<*, *, *>> | (Object) => React.Element<*>, };
+export type EmbedsType = {
+  [string]: Class<React.Component<*, *, *>> | (Object) => React.Element<*>,
+};
 
 export type OptsType = {
   embeds?: EmbedsType,

--- a/lib/types.js
+++ b/lib/types.js
@@ -21,8 +21,10 @@ export type ElementsType = Array<ElementType>;
 export type RenderTextType = Array<TextItemType> => ElementsType;
 export type BlockListType = Array<TextItemType> => ElementsType;
 
+export type EmbedsType = { [string]: Class<React.Component<*, *, *>> | (Object) => React.Element<*>, };
+
 export type OptsType = {
-  embeds?: { [string]: (Object) => React.Element<*>, },
+  embeds?: EmbedsType,
   customCaption?: (ElementsType, ElementsType) => React.Element<*>,
   renderEmptyTextNodes?: boolean,
   customTextFormattings?: Array<{

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 /* @flow */
-/* eslint-disable import/no-extraneous-dependencies, react/display-name, react/prop-types */
+/* eslint-disable import/no-extraneous-dependencies, react/display-name,
+  react/prop-types, react/prefer-stateless-function */
 
 import test from 'tapava';
 import React from 'react';
@@ -41,6 +42,31 @@ test('unknown embed', (t) => {
     embedType: 'unknown-embed',
   }];
   const expected = renderHtmlString(<article />);
+  const actual = renderHtmlString(<Article items={items} />);
+
+  t.is(actual, expected);
+});
+
+test('embed can be class component', (t) => {
+  t.plan(1);
+
+  class CustomEmbed extends React.Component {
+    render() {
+      return <span>Custom Embed</span>;
+    }
+  }
+
+  const Article = setupArticle({
+    embeds: {
+      custom: CustomEmbed,
+    },
+  });
+  const items = [{
+    type: 'embed',
+    embedType: 'custom',
+  }];
+  const expected = renderHtmlString(
+    <article><figure><span>Custom Embed</span></figure></article>);
   const actual = renderHtmlString(<Article items={items} />);
 
   t.is(actual, expected);


### PR DESCRIPTION
Type: Patch

Fixes issue when passing in a class component for rendering embeds.  

TODO: 
- [x] Fix lint
  